### PR TITLE
added missing dependency prosemirror-schema-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "prosemirror-model": "~0.22.0",
     "prosemirror-schema-basic": "~0.22.0",
-    "prosemirror-schema-table": "~0.22.0"
+    "prosemirror-schema-table": "~0.22.0",
+    "prosemirror-schema-list": "~0.22.0"
   },
   "devDependencies": {
     "buble": "^0.15.1",


### PR DESCRIPTION
`prosemirror-schema-list` is used in the package but it is not in the dependencies list.