### PR TITLE
Support marks with same type but different attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "prosemirror-schema-list": "^1.0.0"
   },
   "devDependencies": {
-    "rollup": "^2.26.3",
-    "@rollup/plugin-buble": "^0.21.3"
+    "@rollup/plugin-buble": "^0.21.3",
+    "ist": "1.1.7",
+    "mocha": "9.2.2",
+    "rollup": "^2.26.3"
   },
   "scripts": {
-    "test": "true",
+    "test": "mocha test/test-*.js",
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "prepare": "npm run build"

--- a/src/build.js
+++ b/src/build.js
@@ -74,7 +74,7 @@ function block(type, attrs) {
 function mark(type, attrs) {
   return function(...args) {
     let mark = type.create(takeAttrs(attrs, args))
-    let {nodes, tag} = flatten(type.schema, args, n => mark.type.isInSet(n.marks) ? n : n.mark(mark.addToSet(n.marks)))
+    let {nodes, tag} = flatten(type.schema, args, n => n.mark(mark.addToSet(n.marks)))
     return {flat: nodes, tag}
   }
 }

--- a/test/test-marks.js
+++ b/test/test-marks.js
@@ -1,0 +1,44 @@
+const {builders, eq} = require("..")
+const {Schema} = require("prosemirror-model");
+const ist = require("ist")
+
+// This schema has an "a" mark which doesn't exclude itself
+const nodes = {
+  doc: {
+    content: "block+"
+  },
+  p: {
+    content: "inline*",
+    group: "block",
+  },
+  text: {
+    group: "inline"
+  },
+};
+const marks = {
+  a: {
+    attrs: {
+      href: {},
+    },
+    excludes: ""
+  }
+}
+const schema = new Schema({nodes, marks})
+
+const { doc, p, a } = builders(schema);
+
+describe("Multiple marks", () => {
+    it("deduplicates identical marks", () => {
+        const actual = doc(p(a({ href: "/foo" }, a({ href: "/foo" }, "click <p>here"))));
+        const expected = doc(p(a({ href: "/foo" }, "click here")));
+
+        ist(actual, expected, eq);
+        ist(actual.nodeAt(actual.tag.p).marks.length, 1);
+    });
+
+    it("marks of same type but different attributes are distinct", () => {
+        const actual = doc(p(a({ href: "/foo" }, a({ href: "/bar" }, "click <p>here"))));
+
+        ist(actual.nodeAt(actual.tag.p).marks.length, 2);
+    });
+});


### PR DESCRIPTION
prosemirorr-model's `addToSet` already handles de-duplication, there's
no need for custom logic here.