### PR TITLE
declare Builders type for builders()

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -105,13 +105,13 @@ function mark(type: MarkType, attrs: Attrs | null): MarkBuilder {
 
 export function builders<Nodes extends string = any, Marks extends string = any>(schema: Schema<Nodes, Marks>, names?: {[name: string]: Attrs}) {
   let result = {schema}
-  for (let name in schema.nodes) result[name] = block(schema.nodes[name], {})
-  for (let name in schema.marks) result[name] = mark(schema.marks[name], {})
+  for (let name in schema.nodes) (result as any)[name] = block(schema.nodes[name], {})
+  for (let name in schema.marks) (result as any)[name] = mark(schema.marks[name], {})
 
   if (names) for (let name in names) {
     let value = names[name], typeName = value.nodeType || value.markType || name, type
-    if (type = schema.nodes[typeName]) result[name] = block(type, value)
-    else if (type = schema.marks[typeName]) result[name] = mark(type, value)
+    if (type = schema.nodes[typeName]) (result as any)[name] = block(type, value)
+    else if (type = schema.marks[typeName]) (result as any)[name] = mark(type, value)
   }
   return result as Builders<Schema<Nodes, Marks>>
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -68,6 +68,16 @@ function takeAttrs(attrs: Attrs | null, args: [a?: Attrs | ChildSpec, ...b: Chil
 export type NodeBuilder = (attrsOrFirstChild?: Attrs | ChildSpec, ...children: ChildSpec[]) => Node
 export type MarkBuilder = (attrsOrFirstChild?: Attrs | ChildSpec, ...children: ChildSpec[]) => ChildSpec
 
+type Builders<S extends Schema> = {
+  schema: S;
+} & {
+  [key in keyof S['nodes']]: NodeBuilder
+} & {
+  [key in keyof S['marks']]: MarkBuilder
+} & {
+  [name: string]: NodeBuilder | MarkBuilder
+}
+
 /// Create a builder function for nodes with content.
 function block(type: NodeType, attrs: Attrs | null = null): NodeBuilder {
   let result: NodeBuilder = function(...args) {
@@ -93,15 +103,15 @@ function mark(type: MarkType, attrs: Attrs | null): MarkBuilder {
   }
 }
 
-export function builders(schema: Schema, names?: {[name: string]: Attrs}) {
+export function builders<Nodes extends string = any, Marks extends string = any>(schema: Schema<Nodes, Marks>, names?: {[name: string]: Attrs}) {
   let result = {schema}
-  for (let name in schema.nodes) (result as any)[name] = block(schema.nodes[name], {})
-  for (let name in schema.marks) (result as any)[name] = mark(schema.marks[name], {})
+  for (let name in schema.nodes) result[name] = block(schema.nodes[name], {})
+  for (let name in schema.marks) result[name] = mark(schema.marks[name], {})
 
   if (names) for (let name in names) {
     let value = names[name], typeName = value.nodeType || value.markType || name, type
-    if (type = schema.nodes[typeName]) (result as any)[name] = block(type, value)
-    else if (type = schema.marks[typeName]) (result as any)[name] = mark(type, value)
+    if (type = schema.nodes[typeName]) result[name] = block(type, value)
+    else if (type = schema.marks[typeName]) result[name] = mark(type, value)
   }
-  return result
+  return result as Builders<Schema<Nodes, Marks>>
 }


### PR DESCRIPTION
# Description
This change provides a type that uses the schema and name of the builders argument to return the appropriate object.

# Motivation
Until now, the only explicit return type of builder has been schema.
Therefore, to use the builder in a TypeScript project, it had to be cast to any.

# How Has This Been Tested?
I wanted to modify test-mark.ts, but this file could not reflect the changes because it is imported from npm, not the source code.
I confirmed that [any here](https://github.com/ProseMirror/prosemirror-test-builder/blob/88b9ce4a83b2bcd00bd71bbe1c174b19fe3ac2bf/test/test-marks.ts?plain=1#L28) can be removed, along with this one: https://github.com/ProseMirror/prosemirror-test-builder/pull/10 
I have also confirmed that the type is valid in the test code of a private project I am involved in.

